### PR TITLE
chore: Updates verkle cryptography dependencies to `6036bd`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,12 +168,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1991ff779e077f944746319e1f8ef5c8dd51c692#1991ff779e077f944746319e1f8ef5c8dd51c692"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
 dependencies = [
  "ark-ec",
  "ark-ed-on-bls12-381-bandersnatch",
  "ark-ff",
  "ark-serialize",
+ "rayon",
 ]
 
 [[package]]
@@ -510,9 +511,10 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1991ff779e077f944746319e1f8ef5c8dd51c692#1991ff779e077f944746319e1f8ef5c8dd51c692"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
 dependencies = [
  "banderwagon",
+ "hex",
  "itertools",
  "rayon",
  "sha2",
@@ -1025,12 +1027,12 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "verkle-db"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1991ff779e077f944746319e1f8ef5c8dd51c692#1991ff779e077f944746319e1f8ef5c8dd51c692"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
 
 [[package]]
 name = "verkle-spec"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1991ff779e077f944746319e1f8ef5c8dd51c692#1991ff779e077f944746319e1f8ef5c8dd51c692"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
 dependencies = [
  "ethereum-types",
  "hex",
@@ -1041,7 +1043,7 @@ dependencies = [
 [[package]]
 name = "verkle-trie"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1991ff779e077f944746319e1f8ef5c8dd51c692#1991ff779e077f944746319e1f8ef5c8dd51c692"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
 dependencies = [
  "anyhow",
  "banderwagon",

--- a/src/rust-wasm/Cargo.toml
+++ b/src/rust-wasm/Cargo.toml
@@ -15,10 +15,10 @@ default = ["console_error_panic_hook"]
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.3.0"
 wasm-bindgen = { version = "0.2.90", features = ["serde-serialize"] }
-verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", rev = "1991ff779e077f944746319e1f8ef5c8dd51c692" }
-verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", rev = "1991ff779e077f944746319e1f8ef5c8dd51c692" }
-ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "1991ff779e077f944746319e1f8ef5c8dd51c692" }
-banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "1991ff779e077f944746319e1f8ef5c8dd51c692" }
+verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
+verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
+ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
+banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
 ark-ff = "0.4.0"
 ark-serialize = { version = "^0.4.0", default-features = false }
 

--- a/src/rust-wasm/src/commit.rs
+++ b/src/rust-wasm/src/commit.rs
@@ -40,7 +40,7 @@ impl From<SerializableFrWrapper> for FrWrapper {
 // and then chunk each four u64s into a FrWrapper
 #[wasm_bindgen]
 pub fn commit_scalar_values(arr: &Array) -> Result<ElementWrapper, JsValue> {
-    let committer = DefaultCommitter(new_crs());
+    let committer = DefaultCommitter::new(&new_crs().G);
 
     let mut fr_values = [Fr::zero(); 256];
 


### PR DESCRIPTION
This updates the rust verkle libraries to the most recent commit. It is done so that in later PRs we can switch to using the `ffi_interface` package.

The interface for DefaultCommitter was changed to have a `new` method to instantiate the DefaultCommitter. This has been modified in the PR.