### PR TITLE
chore: use `ffi_interface`  API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,12 +168,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1991ff779e077f944746319e1f8ef5c8dd51c692#1991ff779e077f944746319e1f8ef5c8dd51c692"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
 dependencies = [
  "ark-ec",
  "ark-ed-on-bls12-381-bandersnatch",
  "ark-ff",
  "ark-serialize",
+ "rayon",
 ]
 
 [[package]]
@@ -510,9 +511,10 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1991ff779e077f944746319e1f8ef5c8dd51c692#1991ff779e077f944746319e1f8ef5c8dd51c692"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
 dependencies = [
  "banderwagon",
+ "hex",
  "itertools",
  "rayon",
  "sha2",
@@ -1025,12 +1027,12 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "verkle-db"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1991ff779e077f944746319e1f8ef5c8dd51c692#1991ff779e077f944746319e1f8ef5c8dd51c692"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
 
 [[package]]
 name = "verkle-spec"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1991ff779e077f944746319e1f8ef5c8dd51c692#1991ff779e077f944746319e1f8ef5c8dd51c692"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
 dependencies = [
  "ethereum-types",
  "hex",
@@ -1041,7 +1043,7 @@ dependencies = [
 [[package]]
 name = "verkle-trie"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1991ff779e077f944746319e1f8ef5c8dd51c692#1991ff779e077f944746319e1f8ef5c8dd51c692"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
 dependencies = [
  "anyhow",
  "banderwagon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "ffi_interface"
+version = "0.1.0"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
+dependencies = [
+ "banderwagon",
+ "hex",
+ "ipa-multipoint",
+ "verkle-spec",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +792,7 @@ dependencies = [
  "ark-serialize",
  "banderwagon",
  "console_error_panic_hook",
+ "ffi_interface",
  "getrandom",
  "hex",
  "ipa-multipoint",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "name": "verkle-cryptography-wasm",
       "hasInstallScript": true,
+      "dependencies": {
+        "@ethereumjs/util": "^9.0.2"
+      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.7.3",
         "@typescript-eslint/parser": "^6.7.3",
@@ -463,6 +466,37 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@ethereumjs/rlp": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
+      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
+      "bin": {
+        "rlp": "bin/rlp.cjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ethereumjs/util": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.0.2.tgz",
+      "integrity": "sha512-dasKCj6Vb5spVPnNmRDFHmbfBySvokE440F0RDroPLzO4Mb4hyDqeoOMUxlbLz/BscK2pOpWUendGA+AOvGpNQ==",
+      "dependencies": {
+        "@ethereumjs/rlp": "^5.0.2",
+        "ethereum-cryptography": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "c-kzg": "^2.1.2"
+      },
+      "peerDependenciesMeta": {
+        "c-kzg": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "dev": true,
@@ -525,6 +559,28 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dependencies": {
+        "@noble/hashes": "1.3.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -746,6 +802,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
+      "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.3.tgz",
+      "integrity": "sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==",
+      "dependencies": {
+        "@noble/curves": "~1.3.0",
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.2.tgz",
+      "integrity": "sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==",
+      "dependencies": {
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -2006,6 +2095,17 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.1.3.tgz",
+      "integrity": "sha512-BlwbIL7/P45W8FGW2r7LGuvoEZ+7PWsniMvQ4p5s2xCyw9tmaDlpfsN9HjAucbF+t/qpVHwZUisgfK24TCW8aA==",
+      "dependencies": {
+        "@noble/curves": "1.3.0",
+        "@noble/hashes": "1.3.3",
+        "@scure/bip32": "1.3.3",
+        "@scure/bip39": "1.2.2"
       }
     },
     "node_modules/execa": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,8 @@
     "": {
       "name": "verkle-cryptography-wasm",
       "hasInstallScript": true,
-      "dependencies": {
-        "@ethereumjs/util": "^9.0.2"
-      },
       "devDependencies": {
+        "@ethereumjs/util": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "^6.7.3",
         "@typescript-eslint/parser": "^6.7.3",
         "eslint": "^8.50.0",
@@ -470,6 +468,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
       "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
+      "dev": true,
       "bin": {
         "rlp": "bin/rlp.cjs"
       },
@@ -481,6 +480,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.0.2.tgz",
       "integrity": "sha512-dasKCj6Vb5spVPnNmRDFHmbfBySvokE440F0RDroPLzO4Mb4hyDqeoOMUxlbLz/BscK2pOpWUendGA+AOvGpNQ==",
+      "dev": true,
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "ethereum-cryptography": "^2.1.3"
@@ -565,6 +565,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
       "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dev": true,
       "dependencies": {
         "@noble/hashes": "1.3.3"
       },
@@ -576,6 +577,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
       "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "dev": true,
       "engines": {
         "node": ">= 16"
       },
@@ -807,6 +809,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
       "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
+      "dev": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -815,6 +818,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.3.tgz",
       "integrity": "sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==",
+      "dev": true,
       "dependencies": {
         "@noble/curves": "~1.3.0",
         "@noble/hashes": "~1.3.2",
@@ -828,6 +832,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.2.tgz",
       "integrity": "sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==",
+      "dev": true,
       "dependencies": {
         "@noble/hashes": "~1.3.2",
         "@scure/base": "~1.1.4"
@@ -2101,6 +2106,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.1.3.tgz",
       "integrity": "sha512-BlwbIL7/P45W8FGW2r7LGuvoEZ+7PWsniMvQ4p5s2xCyw9tmaDlpfsN9HjAucbF+t/qpVHwZUisgfK24TCW8aA==",
+      "dev": true,
       "dependencies": {
         "@noble/curves": "1.3.0",
         "@noble/hashes": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,8 @@
     "postinstall": "npm run build",
     "test": "npx vitest run"
   },
-  "dependencies": {
-    "@ethereumjs/util": "^9.0.2"
-  },
   "devDependencies": {
+    "@ethereumjs/util": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",
     "eslint": "^8.50.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "postinstall": "npm run build",
     "test": "npx vitest run"
   },
+  "dependencies": {
+    "@ethereumjs/util": "^9.0.2"
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",

--- a/src/js/tests/ffi.spec.ts
+++ b/src/js/tests/ffi.spec.ts
@@ -1,11 +1,12 @@
+import { bytesToHex } from '@ethereumjs/util'
 import { beforeAll, describe, expect, test } from 'vitest'
 
-import { ContextWrapper } from '../verkleFFIBindings/index'
+import { Context } from '../verkleFFIBindings/index'
 
 describe('bindings', () => {
-  let context: ContextWrapper
+  let context: Context
   beforeAll(() => {
-    context = ContextWrapper._default()
+    context = Context._default()
   })
 
   test('getTreeKey', () => {
@@ -27,9 +28,9 @@ describe('bindings', () => {
     const sub_index = 0
 
     const key = context.getTreeKey(address, tree_index_le, sub_index)
-    const key_hex = Buffer.from(key).toString('hex')
+    const key_hex = bytesToHex(key)
 
-    const expected = '76a014d14e338c57342cda5187775c6b75e7f0ef292e81b176c7a5a700273700'
+    const expected = '0x76a014d14e338c57342cda5187775c6b75e7f0ef292e81b176c7a5a700273700'
 
     expect(key_hex).toBe(expected)
   })
@@ -44,9 +45,9 @@ describe('bindings', () => {
     const scalars = [scalar, scalar]
     const commitment = context.commitToScalars(scalars)
 
-    const commitment_hex = Buffer.from(commitment).toString('hex')
+    const commitment_hex = bytesToHex(commitment)
     const expected =
-      '6fb3421d850da8e8b8d1b9c1cc30876ef23d9df72c8792e6d569a9861089f02abdf89e2c671fe0bff820e815f6f20453fdbc83ec5415e3ade8c745179e31d25c'
+      '0x6fb3421d850da8e8b8d1b9c1cc30876ef23d9df72c8792e6d569a9861089f02abdf89e2c671fe0bff820e815f6f20453fdbc83ec5415e3ade8c745179e31d25c'
 
     expect(commitment_hex).toBe(expected)
   })
@@ -60,9 +61,9 @@ describe('bindings', () => {
     const commitment = context.commitToScalars([scalar])
 
     const commitmentHash = context.hashCommitment(commitment)
-    const commitmentHashHex = Buffer.from(commitmentHash).toString('hex')
+    const commitmentHashHex = bytesToHex(commitmentHash)
 
-    const expected = '31e94bef2c0160ed1f3dd9caacbed356939c2e440c4ddb336d832dcab6384e19'
+    const expected = '0x31e94bef2c0160ed1f3dd9caacbed356939c2e440c4ddb336d832dcab6384e19'
 
     expect(commitmentHashHex).toBe(expected)
   })
@@ -80,9 +81,9 @@ describe('bindings', () => {
 
     for (let i = 0; i < hashes.length; i++) {
       const expectedHash = context.hashCommitment(commitments[i])
-      const expectedHashHex = Buffer.from(expectedHash).toString('hex')
+      const expectedHashHex = bytesToHex(expectedHash)
 
-      const commitmentHashHex = Buffer.from(hashes[i]).toString('hex')
+      const commitmentHashHex = bytesToHex(hashes[i])
 
       expect(commitmentHashHex).toBe(expectedHashHex)
     }
@@ -97,9 +98,9 @@ describe('bindings', () => {
     const commitment = context.commitToScalars([scalar])
 
     const commitmentHash = context.deprecateSerializeCommitment(commitment)
-    const commitmentHashHex = Buffer.from(commitmentHash).toString('hex')
+    const commitmentHashHex = bytesToHex(commitmentHash)
 
-    const expected = '6d40cf3d3097cb19b0ff686a068d53fb1250cc98bbd33766cf2cce00acb8b0a6'
+    const expected = '0x6d40cf3d3097cb19b0ff686a068d53fb1250cc98bbd33766cf2cce00acb8b0a6'
 
     expect(commitmentHashHex).toBe(expected)
   })
@@ -120,7 +121,7 @@ describe('bindings', () => {
     ])
 
     const expected = context.scalarMulIndex(newScalarValue, commitmentIndex)
-    const expectedHex = Buffer.from(expected).toString('hex')
+    const expectedHex = bytesToHex(expected)
 
     const updatedCommitment = context.updateCommitment(
       commitment,
@@ -128,7 +129,7 @@ describe('bindings', () => {
       oldScalarValue,
       newScalarValue,
     )
-    const updatedCommitmentHex = Buffer.from(updatedCommitment).toString('hex')
+    const updatedCommitmentHex = bytesToHex(updatedCommitment)
 
     expect(updatedCommitmentHex).toBe(expectedHex)
   })

--- a/src/js/tests/ffi.spec.ts
+++ b/src/js/tests/ffi.spec.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, test } from 'vitest'
 
 import { ContextWrapper } from '../verkleFFIBindings/index'
 
-describe.only('bindings', () => {
+describe('bindings', () => {
 
     let context: ContextWrapper;
     beforeAll(() => {
@@ -95,7 +95,7 @@ describe.only('bindings', () => {
         expect(commitmentHashHex).toBe(expected);
     })
 
-    test.only('updateCommitment', () => {
+    test('updateCommitment', () => {
 
         // Create a commitment that we can use to update
         const oldScalarValue = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,

--- a/src/js/tests/ffi.spec.ts
+++ b/src/js/tests/ffi.spec.ts
@@ -3,118 +3,133 @@ import { beforeAll, describe, expect, test } from 'vitest'
 import { ContextWrapper } from '../verkleFFIBindings/index'
 
 describe('bindings', () => {
+  let context: ContextWrapper
+  beforeAll(() => {
+    context = ContextWrapper._default()
+  })
 
-    let context: ContextWrapper;
-    beforeAll(() => {
-        context = ContextWrapper._default();
-    })
+  test('getTreeKey', () => {
+    // This is a copy of the test vector in rust-verkle
+    // See: https://github.com/crate-crypto/rust-verkle/blob/6036bde9a8f416648213c59ad0c857b2a6f226f3/ffi_interface/src/lib.rs#L600
+    const address = new Uint8Array([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+      27, 28, 29, 30, 31, 32,
+    ])
 
-    test('getTreeKey', () => {
-        // This is a copy of the test vector in rust-verkle
-        // See: https://github.com/crate-crypto/rust-verkle/blob/6036bde9a8f416648213c59ad0c857b2a6f226f3/ffi_interface/src/lib.rs#L600
-        const address = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 32]);
+    const tree_index_le = new Uint8Array([
+      33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+      56, 57, 58, 59, 60, 61, 62, 63, 64,
+    ])
 
-        const tree_index_le = new Uint8Array([33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
-            47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64]);
+    // Reverse the tree_index array so it is in little endian form
+    tree_index_le.reverse()
 
-        // Reverse the tree_index array so it is in little endian form
-        tree_index_le.reverse();
+    const sub_index = 0
 
-        const sub_index = 0;
+    const key = context.getTreeKey(address, tree_index_le, sub_index)
+    const key_hex = Buffer.from(key).toString('hex')
 
-        const key = context.getTreeKey(address, tree_index_le, sub_index);
-        const key_hex = Buffer.from(key).toString('hex');
+    const expected = '76a014d14e338c57342cda5187775c6b75e7f0ef292e81b176c7a5a700273700'
 
-        const expected = "76a014d14e338c57342cda5187775c6b75e7f0ef292e81b176c7a5a700273700";
+    expect(key_hex).toBe(expected)
+  })
 
-        expect(key_hex).toBe(expected);
-    })
+  test('commitToScalars', () => {
+    const scalar = new Uint8Array([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+      27, 28, 29, 30, 31, 0,
+    ])
 
-    test('commitToScalars', () => {
-        const scalar = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 0]);
+    // Put scalar into a vector of uint8arrays
+    const scalars = [scalar, scalar]
+    const commitment = context.commitToScalars(scalars)
 
-        // Put scalar into a vector of uint8arrays
-        let scalars = [scalar, scalar];
-        const commitment = context.commitToScalars(scalars);
+    const commitment_hex = Buffer.from(commitment).toString('hex')
+    const expected =
+      '6fb3421d850da8e8b8d1b9c1cc30876ef23d9df72c8792e6d569a9861089f02abdf89e2c671fe0bff820e815f6f20453fdbc83ec5415e3ade8c745179e31d25c'
 
-        const commitment_hex = Buffer.from(commitment).toString('hex');
-        const expected = "6fb3421d850da8e8b8d1b9c1cc30876ef23d9df72c8792e6d569a9861089f02abdf89e2c671fe0bff820e815f6f20453fdbc83ec5415e3ade8c745179e31d25c";
+    expect(commitment_hex).toBe(expected)
+  })
 
-        expect(commitment_hex).toBe(expected);
-    })
+  test('hashCommitment', () => {
+    // Create a commitment that we can hash
+    const scalar = new Uint8Array([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+      27, 28, 29, 30, 31, 0,
+    ])
+    const commitment = context.commitToScalars([scalar])
 
-    test('hashCommitment', () => {
+    const commitmentHash = context.hashCommitment(commitment)
+    const commitmentHashHex = Buffer.from(commitmentHash).toString('hex')
 
-        // Create a commitment that we can hash
-        const scalar = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 0]);
-        const commitment = context.commitToScalars([scalar]);
+    const expected = '31e94bef2c0160ed1f3dd9caacbed356939c2e440c4ddb336d832dcab6384e19'
 
-        const commitmentHash = context.hashCommitment(commitment);
-        const commitmentHashHex = Buffer.from(commitmentHash).toString('hex');
+    expect(commitmentHashHex).toBe(expected)
+  })
 
-        const expected = "31e94bef2c0160ed1f3dd9caacbed356939c2e440c4ddb336d832dcab6384e19";
+  test('hashCommitments', () => {
+    // Create a commitment that we can hash
+    const scalar = new Uint8Array([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+      27, 28, 29, 30, 31, 0,
+    ])
+    const commitment = context.commitToScalars([scalar])
 
-        expect(commitmentHashHex).toBe(expected);
-    })
+    const commitments = [commitment, commitment]
+    const hashes = context.hashCommitments([commitment, commitment])
 
-    test('hashCommitments', () => {
+    for (let i = 0; i < hashes.length; i++) {
+      const expectedHash = context.hashCommitment(commitments[i])
+      const expectedHashHex = Buffer.from(expectedHash).toString('hex')
 
-        // Create a commitment that we can hash
-        const scalar = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 0]);
-        const commitment = context.commitToScalars([scalar]);
+      const commitmentHashHex = Buffer.from(hashes[i]).toString('hex')
 
-        const commitments = [commitment, commitment];
-        const hashes = context.hashCommitments([commitment, commitment]);
+      expect(commitmentHashHex).toBe(expectedHashHex)
+    }
+  })
 
-        for (let i = 0; i < hashes.length; i++) {
-            const expectedHash = context.hashCommitment(commitments[i]);
-            const expectedHashHex = Buffer.from(expectedHash).toString('hex');
+  test('serializeCommitment', () => {
+    // Create a commitment that we can hash
+    const scalar = new Uint8Array([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+      27, 28, 29, 30, 31, 0,
+    ])
+    const commitment = context.commitToScalars([scalar])
 
-            const commitmentHashHex = Buffer.from(hashes[i]).toString('hex');
+    const commitmentHash = context.deprecateSerializeCommitment(commitment)
+    const commitmentHashHex = Buffer.from(commitmentHash).toString('hex')
 
-            expect(commitmentHashHex).toBe(expectedHashHex);
-        }
-    })
+    const expected = '6d40cf3d3097cb19b0ff686a068d53fb1250cc98bbd33766cf2cce00acb8b0a6'
 
-    test('serializeCommitment', () => {
+    expect(commitmentHashHex).toBe(expected)
+  })
 
-        // Create a commitment that we can hash
-        const scalar = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 0]);
-        const commitment = context.commitToScalars([scalar]);
+  test('updateCommitment', () => {
+    // Create a commitment that we can use to update
+    const oldScalarValue = new Uint8Array([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+      27, 28, 29, 30, 31, 0,
+    ])
+    const commitmentIndex = 1
+    const commitment = context.scalarMulIndex(oldScalarValue, commitmentIndex)
 
-        const commitmentHash = context.deprecateSerializeCommitment(commitment);
-        const commitmentHashHex = Buffer.from(commitmentHash).toString('hex');
+    // Create a new scalar value to update the commitment with
+    const newScalarValue = new Uint8Array([
+      1, 0, 0, 0, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+      27, 28, 29, 30, 31, 0,
+    ])
 
-        const expected = "6d40cf3d3097cb19b0ff686a068d53fb1250cc98bbd33766cf2cce00acb8b0a6";
+    const expected = context.scalarMulIndex(newScalarValue, commitmentIndex)
+    const expectedHex = Buffer.from(expected).toString('hex')
 
-        expect(commitmentHashHex).toBe(expected);
-    })
+    const updatedCommitment = context.updateCommitment(
+      commitment,
+      commitmentIndex,
+      oldScalarValue,
+      newScalarValue,
+    )
+    const updatedCommitmentHex = Buffer.from(updatedCommitment).toString('hex')
 
-    test('updateCommitment', () => {
-
-        // Create a commitment that we can use to update
-        const oldScalarValue = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 0]);
-        const commitmentIndex = 1;
-        const commitment = context.scalarMulIndex(oldScalarValue, commitmentIndex);
-
-        // Create a new scalar value to update the commitment with
-        const newScalarValue = new Uint8Array([1, 0, 0, 0, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 0]);
-
-        const expected = context.scalarMulIndex(newScalarValue, commitmentIndex);
-        const expectedHex = Buffer.from(expected).toString('hex');
-
-
-        const updatedCommitment = context.updateCommitment(commitment, commitmentIndex, oldScalarValue, newScalarValue);
-        const updatedCommitmentHex = Buffer.from(updatedCommitment).toString('hex');
-
-
-        expect(updatedCommitmentHex).toBe(expectedHex);
-    })
+    expect(updatedCommitmentHex).toBe(expectedHex)
+  })
 })

--- a/src/js/tests/ffi.spec.ts
+++ b/src/js/tests/ffi.spec.ts
@@ -1,0 +1,120 @@
+import { beforeAll, describe, expect, test } from 'vitest'
+
+import { ContextWrapper } from '../verkleFFIBindings/index'
+
+describe.only('bindings', () => {
+
+    let context: ContextWrapper;
+    beforeAll(() => {
+        context = ContextWrapper._default();
+    })
+
+    test('getTreeKey', () => {
+        // This is a copy of the test vector in rust-verkle
+        // See: https://github.com/crate-crypto/rust-verkle/blob/6036bde9a8f416648213c59ad0c857b2a6f226f3/ffi_interface/src/lib.rs#L600
+        const address = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 32]);
+
+        const tree_index_le = new Uint8Array([33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+            47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64]);
+
+        // Reverse the tree_index array so it is in little endian form
+        tree_index_le.reverse();
+
+        const sub_index = 0;
+
+        const key = context.getTreeKey(address, tree_index_le, sub_index);
+        const key_hex = Buffer.from(key).toString('hex');
+
+        const expected = "76a014d14e338c57342cda5187775c6b75e7f0ef292e81b176c7a5a700273700";
+
+        expect(key_hex).toBe(expected);
+    })
+
+    test('commitToScalars', () => {
+        const scalar = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 0]);
+
+        // Put scalar into a vector of uint8arrays
+        let scalars = [scalar, scalar];
+        const commitment = context.commitToScalars(scalars);
+
+        const commitment_hex = Buffer.from(commitment).toString('hex');
+        const expected = "6fb3421d850da8e8b8d1b9c1cc30876ef23d9df72c8792e6d569a9861089f02abdf89e2c671fe0bff820e815f6f20453fdbc83ec5415e3ade8c745179e31d25c";
+
+        expect(commitment_hex).toBe(expected);
+    })
+
+    test('hashCommitment', () => {
+
+        // Create a commitment that we can hash
+        const scalar = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 0]);
+        const commitment = context.commitToScalars([scalar]);
+
+        const commitmentHash = context.hashCommitment(commitment);
+        const commitmentHashHex = Buffer.from(commitmentHash).toString('hex');
+
+        const expected = "31e94bef2c0160ed1f3dd9caacbed356939c2e440c4ddb336d832dcab6384e19";
+
+        expect(commitmentHashHex).toBe(expected);
+    })
+
+    test('hashCommitments', () => {
+
+        // Create a commitment that we can hash
+        const scalar = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 0]);
+        const commitment = context.commitToScalars([scalar]);
+
+        const commitments = [commitment, commitment];
+        const hashes = context.hashCommitments([commitment, commitment]);
+
+        for (let i = 0; i < hashes.length; i++) {
+            const expectedHash = context.hashCommitment(commitments[i]);
+            const expectedHashHex = Buffer.from(expectedHash).toString('hex');
+
+            const commitmentHashHex = Buffer.from(hashes[i]).toString('hex');
+
+            expect(commitmentHashHex).toBe(expectedHashHex);
+        }
+    })
+
+    test('serializeCommitment', () => {
+
+        // Create a commitment that we can hash
+        const scalar = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 0]);
+        const commitment = context.commitToScalars([scalar]);
+
+        const commitmentHash = context.deprecateSerializeCommitment(commitment);
+        const commitmentHashHex = Buffer.from(commitmentHash).toString('hex');
+
+        const expected = "6d40cf3d3097cb19b0ff686a068d53fb1250cc98bbd33766cf2cce00acb8b0a6";
+
+        expect(commitmentHashHex).toBe(expected);
+    })
+
+    test.only('updateCommitment', () => {
+
+        // Create a commitment that we can use to update
+        const oldScalarValue = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 0]);
+        const commitmentIndex = 1;
+        const commitment = context.scalarMulIndex(oldScalarValue, commitmentIndex);
+
+        // Create a new scalar value to update the commitment with
+        const newScalarValue = new Uint8Array([1, 0, 0, 0, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 0]);
+
+        const expected = context.scalarMulIndex(newScalarValue, commitmentIndex);
+        const expectedHex = Buffer.from(expected).toString('hex');
+
+
+        const updatedCommitment = context.updateCommitment(commitment, commitmentIndex, oldScalarValue, newScalarValue);
+        const updatedCommitmentHex = Buffer.from(updatedCommitment).toString('hex');
+
+
+        expect(updatedCommitmentHex).toBe(expectedHex);
+    })
+})

--- a/src/js/verkleFFIBindings/index.ts
+++ b/src/js/verkleFFIBindings/index.ts
@@ -1,0 +1,4 @@
+export {
+    ContextWrapper
+} from '../../../dist/cjs/wasm/rust_verkle_wasm'
+

--- a/src/js/verkleFFIBindings/index.ts
+++ b/src/js/verkleFFIBindings/index.ts
@@ -1,4 +1,4 @@
-import { type ContextWrapper, zeroCommitment } from '../../../dist/cjs/wasm/rust_verkle_wasm'
+import { ContextWrapper as Context, zeroCommitment } from '../../../dist/cjs/wasm/rust_verkle_wasm'
 
 // This is a 32 byte serialized field element
 type Scalar = Uint8Array
@@ -6,8 +6,6 @@ type Scalar = Uint8Array
 // This is a 64 byte serialized point.
 // It is 64 bytes because the point is serialized in uncompressed format.
 type Commitment = Uint8Array
-
-type Context = ContextWrapper
 
 export {
   Scalar,

--- a/src/js/verkleFFIBindings/index.ts
+++ b/src/js/verkleFFIBindings/index.ts
@@ -1,4 +1,4 @@
-import { ContextWrapper, zeroCommitment } from '../../../dist/cjs/wasm/rust_verkle_wasm'
+import { type ContextWrapper, zeroCommitment } from '../../../dist/cjs/wasm/rust_verkle_wasm'
 
 // This is a 32 byte serialized field element
 type Scalar = Uint8Array
@@ -7,11 +7,12 @@ type Scalar = Uint8Array
 // It is 64 bytes because the point is serialized in uncompressed format.
 type Commitment = Uint8Array
 
-export type Context = ContextWrapper
+type Context = ContextWrapper
 
 export {
   Scalar,
   Commitment,
+  Context,
   // This is a function that returns a zero commitment
   // wasm_bindgen does not seem to allow returning constants
   zeroCommitment,

--- a/src/js/verkleFFIBindings/index.ts
+++ b/src/js/verkleFFIBindings/index.ts
@@ -1,1 +1,18 @@
-export { ContextWrapper } from '../../../dist/cjs/wasm/rust_verkle_wasm'
+import { ContextWrapper, zeroCommitment } from '../../../dist/cjs/wasm/rust_verkle_wasm'
+
+// This is a 32 byte serialized field element
+type Scalar = Uint8Array
+
+// This is a 64 byte serialized point.
+// It is 64 bytes because the point is serialized in uncompressed format.
+type Commitment = Uint8Array
+
+export type Context = ContextWrapper
+
+export {
+  Scalar,
+  Commitment,
+  // This is a function that returns a zero commitment
+  // wasm_bindgen does not seem to allow returning constants
+  zeroCommitment,
+}

--- a/src/js/verkleFFIBindings/index.ts
+++ b/src/js/verkleFFIBindings/index.ts
@@ -1,4 +1,1 @@
-export {
-    ContextWrapper
-} from '../../../dist/cjs/wasm/rust_verkle_wasm'
-
+export { ContextWrapper } from '../../../dist/cjs/wasm/rust_verkle_wasm'

--- a/src/rust-wasm/Cargo.toml
+++ b/src/rust-wasm/Cargo.toml
@@ -15,10 +15,10 @@ default = ["console_error_panic_hook"]
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.3.0"
 wasm-bindgen = { version = "0.2.90", features = ["serde-serialize"] }
-verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", rev = "1991ff779e077f944746319e1f8ef5c8dd51c692" }
-verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", rev = "1991ff779e077f944746319e1f8ef5c8dd51c692" }
-ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "1991ff779e077f944746319e1f8ef5c8dd51c692" }
-banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "1991ff779e077f944746319e1f8ef5c8dd51c692" }
+verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
+verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
+ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
+banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
 ark-ff = "0.4.0"
 ark-serialize = { version = "^0.4.0", default-features = false }
 

--- a/src/rust-wasm/Cargo.toml
+++ b/src/rust-wasm/Cargo.toml
@@ -19,6 +19,7 @@ verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036
 verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
 ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
 banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
+ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
 ark-ff = "0.4.0"
 ark-serialize = { version = "^0.4.0", default-features = false }
 

--- a/src/rust-wasm/src/commit.rs
+++ b/src/rust-wasm/src/commit.rs
@@ -40,7 +40,7 @@ impl From<SerializableFrWrapper> for FrWrapper {
 // and then chunk each four u64s into a FrWrapper
 #[wasm_bindgen]
 pub fn commit_scalar_values(arr: &Array) -> Result<ElementWrapper, JsValue> {
-    let committer = DefaultCommitter(new_crs());
+    let committer = DefaultCommitter::new(&new_crs().G);
 
     let mut fr_values = [Fr::zero(); 256];
 

--- a/src/rust-wasm/src/lib.rs
+++ b/src/rust-wasm/src/lib.rs
@@ -3,5 +3,5 @@ mod utils;
 pub mod commit;
 pub mod element;
 pub mod scalar_field;
-
+pub mod verkle_ffi_api;
 // pub mod old_api;

--- a/src/rust-wasm/src/verkle_ffi_api.rs
+++ b/src/rust-wasm/src/verkle_ffi_api.rs
@@ -1,0 +1,176 @@
+use ffi_interface::Context;
+pub use ffi_interface::{CommitmentBytes, ScalarBytes, ZERO_POINT};
+use ipa_multipoint::committer::Committer;
+use js_sys::Uint8Array;
+use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
+
+#[wasm_bindgen]
+pub struct ContextWrapper {
+    pub(crate) inner: Context,
+}
+
+#[wasm_bindgen]
+impl ContextWrapper {
+    /// Default constructor to initialize the context
+    ///
+    /// This context holds the necessary configurations to allow you to
+    /// modify the verkle trie structure, including the ability to ability
+    /// to make and verify proofs
+    #[wasm_bindgen(js_name = "default")]
+    pub fn default() -> Self {
+        Self {
+            inner: Context::default(),
+        }
+    }
+    /// Computes `get_tree_key` method as specified in the verkle hackmd.
+    /// See: https://notes.ethereum.org/@vbuterin/verkle_tree_eip#Header-values
+    #[wasm_bindgen(js_name = "getTreeKey")]
+    pub fn get_tree_key(
+        &self,
+        address: Uint8Array,
+        tree_index_le: Uint8Array,
+        sub_index: u8,
+    ) -> Uint8Array {
+        // TODO: This will silently truncate values which are not 32 bytes
+        // TODO We should return an error instead
+        let address = js_value_to_bytes::<32>(address.into());
+        let tree_index_le = js_value_to_bytes::<32>(tree_index_le.into());
+
+        let key =
+            ffi_interface::get_tree_key(&self.inner.committer, address, tree_index_le, sub_index);
+
+        bytes_to_js_value(key).into()
+    }
+
+    /// Commits to a collection of scalar values, returning the commitment in
+    /// uncompressed form.
+    #[wasm_bindgen(js_name = "commitToScalars")]
+    pub fn commit_to_scalars(&self, scalars: Vec<Uint8Array>) -> Uint8Array {
+        let scalars: Vec<u8> = scalars
+            .into_iter()
+            .map(|scalar| js_value_to_bytes::<32>(scalar.into()))
+            .flatten()
+            .collect();
+
+        let commitment = ffi_interface::commit_to_scalars(&self.inner.committer, &scalars)
+            .expect("could not commit to scalars");
+
+        bytes_to_js_value(commitment).into()
+    }
+    /// Computes the hash of a commitment, returning a scalar value
+    #[wasm_bindgen(js_name = "hashCommitment")]
+    pub fn hash_commitment(&self, commitment: Uint8Array) -> Uint8Array {
+        let commitment = js_value_to_bytes::<64>(commitment.into());
+
+        let hash = ffi_interface::hash_commitment(commitment);
+
+        bytes_to_js_value(hash).into()
+    }
+
+    /// Computes the hash of multiple commitment, returning a vector of scalar values.
+    ///
+    /// Note: This is an optimization for the `hashCommitment` method. The only reason to
+    /// use `hashCommitment` is if the caller cannot take benefit of the optimization yet.
+    ///
+    /// This method will be more efficient than calling `hashCommitment` multiple times
+    #[wasm_bindgen(js_name = "hashCommitments")]
+    pub fn hash_commitments(&self, commitments: Vec<Uint8Array>) -> Vec<Uint8Array> {
+        let commitments: Vec<CommitmentBytes> = commitments
+            .into_iter()
+            .map(|commitment| js_value_to_bytes::<64>(commitment.into()))
+            .collect();
+
+        let hashes = ffi_interface::hash_commitments(&commitments);
+
+        hashes
+            .into_iter()
+            .map(|hash| bytes_to_js_value(hash).into())
+            .collect()
+    }
+
+    /// Serialize a commitment, returning 32 bytes.
+    ///
+    /// This method does not return a scalar value, it returns 32 bytes.
+    ///
+    /// Note: We plan to deprecate this method from the public API in favour of using hash commitment
+    /// This method will only be used internally once that is done.
+    #[wasm_bindgen(js_name = "deprecateSerializeCommitment")]
+    pub fn serialize_commitment(&self, commitment: Uint8Array) -> Uint8Array {
+        let commitment = js_value_to_bytes::<64>(commitment.into());
+
+        let hash = ffi_interface::deprecated_serialize_commitment(commitment);
+
+        bytes_to_js_value(hash).into()
+    }
+
+    /// Updates a commitment from aG to bG.
+    ///
+    /// This is an optimization for recomputing the commitment using scalar multiplication.
+    ///
+    /// Short explanation: If a single value in a commitment changes, the naive way to recompute the commitment
+    /// would be to recommit to all the values with the new value.
+    ///
+    /// This is quite inefficient as it can require O(n) scalar multiplications naively or O(n log n) using pippenger.
+    ///
+    /// This method allows you to update a single value in the commitment with a new value using O(1) scalar multiplications.
+    /// This simply means that an update does not scale with the number of values committed to.
+    ///
+    #[wasm_bindgen(js_name = "updateCommitment")]
+    pub fn update_commitment(
+        &self,
+        commitment: Uint8Array,
+        commitment_index: u8,
+        old_scalar_value: Uint8Array,
+        new_scalar_value: Uint8Array,
+    ) -> Uint8Array {
+        let commitment = js_value_to_bytes::<64>(commitment.into());
+
+        let old_scalar_value = js_value_to_bytes::<32>(old_scalar_value.into());
+        let new_scalar_value = js_value_to_bytes::<32>(new_scalar_value.into());
+
+        let updated_commitment = ffi_interface::update_commitment(
+            &self.inner.committer,
+            commitment,
+            commitment_index,
+            old_scalar_value,
+            new_scalar_value,
+        )
+        .unwrap();
+
+        bytes_to_js_value(updated_commitment).into()
+    }
+
+    /// This method should ideally only be used for tests.
+    ///
+    /// For updating a commitment, one should use the `update_commitment` method
+    #[wasm_bindgen(js_name = "scalarMulIndex")]
+    pub fn scalar_mul_index(&self, scalar_value: Uint8Array, commitment_index: u8) -> Uint8Array {
+        fn fr_from_le_bytes(bytes: &[u8]) -> banderwagon::Fr {
+            use banderwagon::trait_defs::*;
+            banderwagon::Fr::deserialize_uncompressed(bytes)
+                .expect("could not deserialize scalar field")
+        }
+
+        let scalar = fr_from_le_bytes(&js_value_to_bytes::<32>(scalar_value.into()));
+
+        let commitment = self
+            .inner
+            .committer
+            .scalar_mul(scalar, commitment_index as usize)
+            .to_bytes_uncompressed();
+
+        bytes_to_js_value(commitment).into()
+    }
+}
+
+// TODO: This will silently truncate values which are not N bytes
+// TODO We should return an error instead
+fn js_value_to_bytes<const N: usize>(value: JsValue) -> [u8; N] {
+    let array = js_sys::Uint8Array::new(&value);
+    let mut result = [0u8; N];
+    array.copy_to(&mut result);
+    result
+}
+fn bytes_to_js_value<const N: usize>(bytes: [u8; N]) -> JsValue {
+    js_sys::Uint8Array::from(&bytes[..]).into()
+}

--- a/src/rust-wasm/src/verkle_ffi_api.rs
+++ b/src/rust-wasm/src/verkle_ffi_api.rs
@@ -58,6 +58,8 @@ impl ContextWrapper {
         bytes_to_js_value(commitment).into()
     }
     /// Computes the hash of a commitment, returning a scalar value
+    ///
+    // Note: This method does need context. It is here for API convenience.
     #[wasm_bindgen(js_name = "hashCommitment")]
     pub fn hash_commitment(&self, commitment: Uint8Array) -> Uint8Array {
         let commitment = js_value_to_bytes::<64>(commitment.into());
@@ -73,6 +75,8 @@ impl ContextWrapper {
     /// use `hashCommitment` is if the caller cannot take benefit of the optimization yet.
     ///
     /// This method will be more efficient than calling `hashCommitment` multiple times
+    ///
+    // Note: This method does need context. It is here for API convenience.
     #[wasm_bindgen(js_name = "hashCommitments")]
     pub fn hash_commitments(&self, commitments: Vec<Uint8Array>) -> Vec<Uint8Array> {
         let commitments: Vec<CommitmentBytes> = commitments
@@ -110,11 +114,10 @@ impl ContextWrapper {
     /// Short explanation: If a single value in a commitment changes, the naive way to recompute the commitment
     /// would be to recommit to all the values with the new value.
     ///
-    /// This is quite inefficient as it can require O(n) scalar multiplications naively or O(n log n) using pippenger.
+    /// This is quite inefficient as it can require O(n) scalar multiplications naively or O(n log n) using Pippenger.
     ///
     /// This method allows you to update a single value in the commitment with a new value using O(1) scalar multiplications.
     /// This simply means that an update does not scale with the number of values committed to.
-    ///
     #[wasm_bindgen(js_name = "updateCommitment")]
     pub fn update_commitment(
         &self,
@@ -161,6 +164,12 @@ impl ContextWrapper {
 
         bytes_to_js_value(commitment).into()
     }
+}
+
+/// This is the default commitment to use when nothing has been committed to
+#[wasm_bindgen(js_name = "zeroCommitment")]
+pub fn zero_commitment() -> Uint8Array {
+    bytes_to_js_value(ffi_interface::ZERO_POINT).into()
 }
 
 // TODO: This will silently truncate values which are not N bytes


### PR DESCRIPTION
This PR adds a new API which relies on the `ffi_interface` API that has been recently been added.

This is the same API that is being used in the besu client and so this should allow one to debug between clients easier.


In terms of performance degradation, I think we can use raw pointers if we want to squeeze out performance, the downside of raw pointers is that memory management is left upto the developer.