### PR TITLE
chore!: modify getTreeKeyHash to use `hashCommitment`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
 dependencies = [
  "ark-ec",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -395,7 +395,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 [[package]]
 name = "ffi_interface"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
 dependencies = [
  "banderwagon",
  "hex",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
 dependencies = [
  "banderwagon",
  "hex",
@@ -1039,12 +1039,12 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "verkle-db"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
 
 [[package]]
 name = "verkle-spec"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
 dependencies = [
  "ethereum-types",
  "hex",
@@ -1055,7 +1055,7 @@ dependencies = [
 [[package]]
 name = "verkle-trie"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=6036bde9a8f416648213c59ad0c857b2a6f226f3#6036bde9a8f416648213c59ad0c857b2a6f226f3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
 dependencies = [
  "anyhow",
  "banderwagon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=737020069832c126bcae163a4e788f6879dfd6a6#737020069832c126bcae163a4e788f6879dfd6a6"
 dependencies = [
  "ark-ec",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -395,7 +395,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 [[package]]
 name = "ffi_interface"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=737020069832c126bcae163a4e788f6879dfd6a6#737020069832c126bcae163a4e788f6879dfd6a6"
 dependencies = [
  "banderwagon",
  "hex",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=737020069832c126bcae163a4e788f6879dfd6a6#737020069832c126bcae163a4e788f6879dfd6a6"
 dependencies = [
  "banderwagon",
  "hex",
@@ -1039,13 +1039,14 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "verkle-db"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=737020069832c126bcae163a4e788f6879dfd6a6#737020069832c126bcae163a4e788f6879dfd6a6"
 
 [[package]]
 name = "verkle-spec"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=737020069832c126bcae163a4e788f6879dfd6a6#737020069832c126bcae163a4e788f6879dfd6a6"
 dependencies = [
+ "banderwagon",
  "ethereum-types",
  "hex",
  "ipa-multipoint",
@@ -1055,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "verkle-trie"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=eac18c4a9eb24c0313d642a9b59be11d295e1b94#eac18c4a9eb24c0313d642a9b59be11d295e1b94"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=737020069832c126bcae163a4e788f6879dfd6a6#737020069832c126bcae163a4e788f6879dfd6a6"
 dependencies = [
  "anyhow",
  "banderwagon",

--- a/src/js/tests/ffi.spec.ts
+++ b/src/js/tests/ffi.spec.ts
@@ -30,7 +30,7 @@ describe('bindings', () => {
     const key = context.getTreeKey(address, treeIndexLE, subIndex)
     const keyHex = bytesToHex(key)
 
-    const expected = '0x76a014d14e338c57342cda5187775c6b75e7f0ef292e81b176c7a5a700273700'
+    const expected = '0xff7e3916badeb510dfcdad458726273319280742e553d8d229bd676428147300'
 
     expect(keyHex).toBe(expected)
   })
@@ -111,21 +111,6 @@ describe('bindings', () => {
     }
   })
 
-  test('serializeCommitment', () => {
-    // Create a commitment that we can hash
-    const scalar = new Uint8Array([
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-      27, 28, 29, 30, 31, 0,
-    ])
-    const commitment = context.commitToScalars([scalar])
-
-    const commitmentHash = context.deprecateSerializeCommitment(commitment)
-    const commitmentHashHex = bytesToHex(commitmentHash)
-
-    const expected = '0x6d40cf3d3097cb19b0ff686a068d53fb1250cc98bbd33766cf2cce00acb8b0a6'
-
-    expect(commitmentHashHex).toBe(expected)
-  })
 
   test('updateCommitment', () => {
     // Create a commitment that we can use to update

--- a/src/js/tests/ffi.spec.ts
+++ b/src/js/tests/ffi.spec.ts
@@ -111,7 +111,6 @@ describe('bindings', () => {
     }
   })
 
-
   test('updateCommitment', () => {
     // Create a commitment that we can use to update
     const oldScalarValue = new Uint8Array([

--- a/src/js/verkleFFIBindings/getTreeKey.ts
+++ b/src/js/verkleFFIBindings/getTreeKey.ts
@@ -96,12 +96,9 @@ function getTreeKeyHash(
   // Note: that the .reverse() below is an implementation detail of the underlying
   // Note: serialization code returning big endian.
   //
-  // TODO: We want to eventually replace deprecateSerializeCommitment with `hashCommitment`
-  // TODO: This is a breaking change, so requires more coordination between different implementations
-  // TODO: once that is done, we can remove the .reverse and the deprecateSerializeCommitment method.
-  //
+
   const commitment = context.commitTo16ByteScalars(chunks)
-  const serializedCommitment = context.deprecateSerializeCommitment(commitment).reverse()
+  const serializedCommitment = context.hashCommitment(commitment)
   return serializedCommitment
 }
 

--- a/src/rust-wasm/Cargo.toml
+++ b/src/rust-wasm/Cargo.toml
@@ -15,11 +15,11 @@ default = ["console_error_panic_hook"]
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.3.0"
 wasm-bindgen = { version = "0.2.90", features = ["serde-serialize"] }
-verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", rev = "eac18c4a9eb24c0313d642a9b59be11d295e1b94" }
-verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", rev = "eac18c4a9eb24c0313d642a9b59be11d295e1b94" }
-ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "eac18c4a9eb24c0313d642a9b59be11d295e1b94" }
-banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "eac18c4a9eb24c0313d642a9b59be11d295e1b94" }
-ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "eac18c4a9eb24c0313d642a9b59be11d295e1b94" }
+verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", rev = "737020069832c126bcae163a4e788f6879dfd6a6" }
+verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", rev = "737020069832c126bcae163a4e788f6879dfd6a6" }
+ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "737020069832c126bcae163a4e788f6879dfd6a6" }
+banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "737020069832c126bcae163a4e788f6879dfd6a6" }
+ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "737020069832c126bcae163a4e788f6879dfd6a6" }
 ark-ff = "0.4.0"
 ark-serialize = { version = "^0.4.0", default-features = false }
 

--- a/src/rust-wasm/Cargo.toml
+++ b/src/rust-wasm/Cargo.toml
@@ -15,11 +15,11 @@ default = ["console_error_panic_hook"]
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.3.0"
 wasm-bindgen = { version = "0.2.90", features = ["serde-serialize"] }
-verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
-verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
-ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
-banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
-ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "6036bde9a8f416648213c59ad0c857b2a6f226f3" }
+verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", rev = "eac18c4a9eb24c0313d642a9b59be11d295e1b94" }
+verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", rev = "eac18c4a9eb24c0313d642a9b59be11d295e1b94" }
+ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "eac18c4a9eb24c0313d642a9b59be11d295e1b94" }
+banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "eac18c4a9eb24c0313d642a9b59be11d295e1b94" }
+ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "eac18c4a9eb24c0313d642a9b59be11d295e1b94" }
 ark-ff = "0.4.0"
 ark-serialize = { version = "^0.4.0", default-features = false }
 

--- a/src/rust-wasm/src/verkle_ffi_api.rs
+++ b/src/rust-wasm/src/verkle_ffi_api.rs
@@ -34,8 +34,7 @@ impl Context {
         let address = js_value_to_bytes::<32>(address.into())?;
         let tree_index_le = js_value_to_bytes::<32>(tree_index_le.into())?;
 
-        let key =
-            ffi_interface::get_tree_key(&self.inner.committer, address, tree_index_le, sub_index);
+        let key = ffi_interface::get_tree_key(&self.inner, address, tree_index_le, sub_index);
 
         Ok(bytes_to_js_value(key).into())
     }
@@ -49,7 +48,7 @@ impl Context {
             scalars.extend(js_value_to_bytes::<32>(scalar.into())?);
         }
 
-        let commitment = ffi_interface::commit_to_scalars(&self.inner.committer, &scalars)
+        let commitment = ffi_interface::commit_to_scalars(&self.inner, &scalars)
             .map_err(|err| JsError::new(&format!("could not commit to scalars: {:?}", err)))?;
 
         Ok(bytes_to_js_value(commitment).into())
@@ -75,7 +74,7 @@ impl Context {
             scalars.extend([0u8; 16]);
         }
 
-        let commitment = ffi_interface::commit_to_scalars(&self.inner.committer, &scalars)
+        let commitment = ffi_interface::commit_to_scalars(&self.inner, &scalars)
             .map_err(|err| JsError::new(&format!("could not commit to scalars: {:?}", err)))?;
 
         Ok(bytes_to_js_value(commitment).into())
@@ -118,21 +117,6 @@ impl Context {
             .collect())
     }
 
-    /// Serialize a commitment, returning 32 bytes.
-    ///
-    /// This method does not return a scalar value, it returns 32 bytes.
-    ///
-    /// Note: We plan to deprecate this method from the public API in favour of using hash commitment
-    /// This method will only be used internally once that is done.
-    #[wasm_bindgen(js_name = "deprecateSerializeCommitment")]
-    pub fn serialize_commitment(&self, commitment: Uint8Array) -> Result<Uint8Array, JsError> {
-        let commitment = js_value_to_bytes::<64>(commitment.into())?;
-
-        let hash = ffi_interface::deprecated_serialize_commitment(commitment);
-
-        Ok(bytes_to_js_value(hash).into())
-    }
-
     /// Updates a commitment from aG to bG.
     ///
     /// This is an optimization for recomputing the commitment using scalar multiplication.
@@ -158,7 +142,7 @@ impl Context {
         let new_scalar_value = js_value_to_bytes::<32>(new_scalar_value.into())?;
 
         let updated_commitment = ffi_interface::update_commitment(
-            &self.inner.committer,
+            &self.inner,
             commitment,
             commitment_index,
             old_scalar_value,


### PR DESCRIPTION
## Rationale

We remove the TODO that was in the codebase related to using `hashCommitment` for `getTreeKeyHash`. 

This is breaking change, so it might make sense for the go-ethereum related PR to be merged first.

The related issue is: https://github.com/crate-crypto/rust-verkle/issues/86