### PR TITLE
chore: postifx `wasm` when copying CJS directory

### DIFF
--- a/scripts/rust-build.sh
+++ b/scripts/rust-build.sh
@@ -74,7 +74,7 @@ ESM_WASM=${ESM_DIR}/${PNAME}_bg.wasm
 # Build the new wasm package
 run_or_fail cargo build --lib --release --target $TARGET
 run_or_fail wasm-bindgen $WASM_BINARY --out-dir $CJS_DIR --typescript --target nodejs
-cp -Rf $CJS_DIR $JS_SRC_DIR/wasm2
+cp -Rf $CJS_DIR $JS_SRC_DIR/wasm
 run_or_fail wasm-bindgen $WASM_BINARY --out-dir $ESM_DIR --typescript --target web
 run_if_available wasm-opt $CJS_WASM -o $CJS_WASM -O
 run_if_available wasm-opt $ESM_WASM -o $ESM_WASM -O

--- a/scripts/rust-build.sh
+++ b/scripts/rust-build.sh
@@ -74,7 +74,7 @@ ESM_WASM=${ESM_DIR}/${PNAME}_bg.wasm
 # Build the new wasm package
 run_or_fail cargo build --lib --release --target $TARGET
 run_or_fail wasm-bindgen $WASM_BINARY --out-dir $CJS_DIR --typescript --target nodejs
-cp -Rf $CJS_DIR $JS_SRC_DIR
+cp -Rf $CJS_DIR $JS_SRC_DIR/wasm
 run_or_fail wasm-bindgen $WASM_BINARY --out-dir $ESM_DIR --typescript --target web
 run_if_available wasm-opt $CJS_WASM -o $CJS_WASM -O
 run_if_available wasm-opt $ESM_WASM -o $ESM_WASM -O

--- a/scripts/rust-build.sh
+++ b/scripts/rust-build.sh
@@ -74,7 +74,7 @@ ESM_WASM=${ESM_DIR}/${PNAME}_bg.wasm
 # Build the new wasm package
 run_or_fail cargo build --lib --release --target $TARGET
 run_or_fail wasm-bindgen $WASM_BINARY --out-dir $CJS_DIR --typescript --target nodejs
-cp -Rf $CJS_DIR $JS_SRC_DIR/wasm
+cp -Rf $CJS_DIR $JS_SRC_DIR/wasm2
 run_or_fail wasm-bindgen $WASM_BINARY --out-dir $ESM_DIR --typescript --target web
 run_if_available wasm-opt $CJS_WASM -o $CJS_WASM -O
 run_if_available wasm-opt $ESM_WASM -o $ESM_WASM -O

--- a/scripts/rust-build.sh
+++ b/scripts/rust-build.sh
@@ -65,16 +65,16 @@ fi
 TARGET=wasm32-unknown-unknown
 WASM_BINARY=$SELF_DIR/target/$TARGET/release/${PNAME}.wasm
 
-CJS_DIR=$SELF_DIR/dist/cjs/wasm/
-ESM_DIR=$SELF_DIR/dist/esm/wasm/
-JS_SRC_DIR=$SELF_DIR/src.ts/
+CJS_DIR=$SELF_DIR/dist/cjs/wasm
+ESM_DIR=$SELF_DIR/dist/esm/wasm
+JS_SRC_DIR=$SELF_DIR/src.ts
 CJS_WASM=${CJS_DIR}/${PNAME}_bg.wasm
 ESM_WASM=${ESM_DIR}/${PNAME}_bg.wasm
 
 # Build the new wasm package
 run_or_fail cargo build --lib --release --target $TARGET
 run_or_fail wasm-bindgen $WASM_BINARY --out-dir $CJS_DIR --typescript --target nodejs
-cp -Rf $CJS_DIR $JS_SRC_DIR/wasm
+cp -Rf $CJS_DIR $JS_SRC_DIR/
 run_or_fail wasm-bindgen $WASM_BINARY --out-dir $ESM_DIR --typescript --target web
 run_if_available wasm-opt $CJS_WASM -o $CJS_WASM -O
 run_if_available wasm-opt $ESM_WASM -o $ESM_WASM -O


### PR DESCRIPTION
This description has been modified after the fact.

The issue I was facing was that building locally was failing. It was failing because the rust-build script was not copying the `wasm` directory into `src.ts`. It was copying the contents of the `wasm` directory which created issues because we are using relative paths to refer to the contents of the `wasm` directory, ie `../wasm/foo.js`

If you are on linux, then I believe you will see no difference. If you are on Mac, then this should fix your local build.