### PR TITLE
New Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to 
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.2.1 - 2024-03-11
+
+- Remove `postinstall` build hook, PR [#35](https://github.com/ethereumjs/verkle-cryptography-wasm/pull/35)
+
 ## 0.2.0 - 2024-03-08
 
 - Limit API exposure to FFI, PR [#32](https://github.com/ethereumjs/verkle-cryptography-wasm/pull/32)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verkle-cryptography-wasm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Verkle Trie Crytography WASM/TypeScript Bindings",
   "keywords": [
     "ethereum",
@@ -39,7 +39,6 @@
     "clean": "rm -rf node_modules dist",
     "lint": "eslint .",
     "lint:fix": "eslint --fix --config ./.eslintrc.js . --ext .js,.jsx,.ts,.tsx",
-    "postinstall": "npm run build",
     "test": "npx vitest run"
   },
   "devDependencies": {


### PR DESCRIPTION
Follow-up on #33 
Replaces #34 

Small release deleting the `postinstall` hook leading to installations to break.

Will directly do a release here so that we can move forward.