### PR TITLE
chore: update rust-verkle dependency and remove now unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=7688f0aedfb147d3d391abfe8495e46c46d72ce0#7688f0aedfb147d3d391abfe8495e46c46d72ce0"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=594a70e3df16db9d870b7d3c82479d041cfd1b2d#594a70e3df16db9d870b7d3c82479d041cfd1b2d"
 dependencies = [
  "ark-ec",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -395,12 +395,13 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 [[package]]
 name = "ffi_interface"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=7688f0aedfb147d3d391abfe8495e46c46d72ce0#7688f0aedfb147d3d391abfe8495e46c46d72ce0"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=594a70e3df16db9d870b7d3c82479d041cfd1b2d#594a70e3df16db9d870b7d3c82479d041cfd1b2d"
 dependencies = [
  "banderwagon",
  "hex",
  "ipa-multipoint",
  "verkle-spec",
+ "verkle-trie",
 ]
 
 [[package]]
@@ -522,7 +523,7 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=7688f0aedfb147d3d391abfe8495e46c46d72ce0#7688f0aedfb147d3d391abfe8495e46c46d72ce0"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=594a70e3df16db9d870b7d3c82479d041cfd1b2d#594a70e3df16db9d870b7d3c82479d041cfd1b2d"
 dependencies = [
  "banderwagon",
  "hex",
@@ -788,8 +789,6 @@ dependencies = [
 name = "rust_verkle_wasm"
 version = "0.1.0"
 dependencies = [
- "ark-ff",
- "ark-serialize",
  "banderwagon",
  "console_error_panic_hook",
  "ffi_interface",
@@ -799,8 +798,6 @@ dependencies = [
  "js-sys",
  "serde",
  "serde-wasm-bindgen",
- "verkle-spec",
- "verkle-trie",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -1039,12 +1036,12 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "verkle-db"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=7688f0aedfb147d3d391abfe8495e46c46d72ce0#7688f0aedfb147d3d391abfe8495e46c46d72ce0"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=594a70e3df16db9d870b7d3c82479d041cfd1b2d#594a70e3df16db9d870b7d3c82479d041cfd1b2d"
 
 [[package]]
 name = "verkle-spec"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=7688f0aedfb147d3d391abfe8495e46c46d72ce0#7688f0aedfb147d3d391abfe8495e46c46d72ce0"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=594a70e3df16db9d870b7d3c82479d041cfd1b2d#594a70e3df16db9d870b7d3c82479d041cfd1b2d"
 dependencies = [
  "banderwagon",
  "ethereum-types",
@@ -1056,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "verkle-trie"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=7688f0aedfb147d3d391abfe8495e46c46d72ce0#7688f0aedfb147d3d391abfe8495e46c46d72ce0"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=594a70e3df16db9d870b7d3c82479d041cfd1b2d#594a70e3df16db9d870b7d3c82479d041cfd1b2d"
 dependencies = [
  "anyhow",
  "banderwagon",
@@ -1066,6 +1063,8 @@ dependencies = [
  "once_cell",
  "rand_chacha",
  "rayon",
+ "serde",
+ "serde_json",
  "sha2",
  "smallvec",
  "tempfile",

--- a/src.rs/Cargo.toml
+++ b/src.rs/Cargo.toml
@@ -15,15 +15,11 @@ default = ["console_error_panic_hook"]
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.3.0"
 wasm-bindgen = { version = "0.2.90", features = ["serde-serialize"] }
-verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", rev = "7688f0aedfb147d3d391abfe8495e46c46d72ce0" }
-verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", rev = "7688f0aedfb147d3d391abfe8495e46c46d72ce0" }
-ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "7688f0aedfb147d3d391abfe8495e46c46d72ce0" }
-banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "7688f0aedfb147d3d391abfe8495e46c46d72ce0" }
-ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "7688f0aedfb147d3d391abfe8495e46c46d72ce0" }
-ark-ff = "0.4.0"
-ark-serialize = { version = "^0.4.0", default-features = false }
+ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "594a70e3df16db9d870b7d3c82479d041cfd1b2d" }
+banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "594a70e3df16db9d870b7d3c82479d041cfd1b2d" }
+ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "594a70e3df16db9d870b7d3c82479d041cfd1b2d" }
 
-hex = "*"
+hex = "0.4.3"
 # This is needed so that we can enable the js feature, which is being used in ark-serialize
 # Without it, the wasm will not compile, since we cannot conditionally compile ark-serialize
 getrandom = { version = "0.2.3", features = ["js"] }


### PR DESCRIPTION
This PR:

- Updates the rust-verkle dependency to `594a70e3df16db9d870b7d3c82479d041cfd1b2d` where we added a method to verify the prestate root in the execution witness. See #44 for usage.

- Removes now un-needed dependencies. Since we are using `ffi_interface` it exposes a more higher level API, which means that this repo no longer needs to manage those dependencies explicitly.