### PR TITLE
fix: On malformed proof elements, return false when verifying the execution witness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "banderwagon"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1c2cd88661e0bf54df29239333baba4bd115c3d3#1c2cd88661e0bf54df29239333baba4bd115c3d3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=309cdcba4088e698689dc33b8ee071c2d064b2ae#309cdcba4088e698689dc33b8ee071c2d064b2ae"
 dependencies = [
  "ark-ec",
  "ark-ed-on-bls12-381-bandersnatch",
@@ -395,7 +395,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 [[package]]
 name = "ffi_interface"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1c2cd88661e0bf54df29239333baba4bd115c3d3#1c2cd88661e0bf54df29239333baba4bd115c3d3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=309cdcba4088e698689dc33b8ee071c2d064b2ae#309cdcba4088e698689dc33b8ee071c2d064b2ae"
 dependencies = [
  "banderwagon",
  "hex",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "ipa-multipoint"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1c2cd88661e0bf54df29239333baba4bd115c3d3#1c2cd88661e0bf54df29239333baba4bd115c3d3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=309cdcba4088e698689dc33b8ee071c2d064b2ae#309cdcba4088e698689dc33b8ee071c2d064b2ae"
 dependencies = [
  "banderwagon",
  "hex",
@@ -1036,12 +1036,12 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "verkle-db"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1c2cd88661e0bf54df29239333baba4bd115c3d3#1c2cd88661e0bf54df29239333baba4bd115c3d3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=309cdcba4088e698689dc33b8ee071c2d064b2ae#309cdcba4088e698689dc33b8ee071c2d064b2ae"
 
 [[package]]
 name = "verkle-spec"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1c2cd88661e0bf54df29239333baba4bd115c3d3#1c2cd88661e0bf54df29239333baba4bd115c3d3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=309cdcba4088e698689dc33b8ee071c2d064b2ae#309cdcba4088e698689dc33b8ee071c2d064b2ae"
 dependencies = [
  "banderwagon",
  "ethereum-types",
@@ -1053,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "verkle-trie"
 version = "0.1.0"
-source = "git+https://github.com/crate-crypto/rust-verkle?rev=1c2cd88661e0bf54df29239333baba4bd115c3d3#1c2cd88661e0bf54df29239333baba4bd115c3d3"
+source = "git+https://github.com/crate-crypto/rust-verkle?rev=309cdcba4088e698689dc33b8ee071c2d064b2ae#309cdcba4088e698689dc33b8ee071c2d064b2ae"
 dependencies = [
  "anyhow",
  "banderwagon",

--- a/src.rs/Cargo.toml
+++ b/src.rs/Cargo.toml
@@ -15,9 +15,9 @@ default = ["console_error_panic_hook"]
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.3.0"
 wasm-bindgen = { version = "0.2.90", features = ["serde-serialize"] }
-ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "1c2cd88661e0bf54df29239333baba4bd115c3d3" }
-banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "1c2cd88661e0bf54df29239333baba4bd115c3d3" }
-ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "1c2cd88661e0bf54df29239333baba4bd115c3d3" }
+ipa-multipoint = { git = "https://github.com/crate-crypto/rust-verkle", rev = "309cdcba4088e698689dc33b8ee071c2d064b2ae" }
+banderwagon = { git = "https://github.com/crate-crypto/rust-verkle", rev = "309cdcba4088e698689dc33b8ee071c2d064b2ae" }
+ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "309cdcba4088e698689dc33b8ee071c2d064b2ae" }
 
 hex = "0.4.3"
 # This is needed so that we can enable the js feature, which is being used in ark-serialize

--- a/src.ts/tests/ffi.spec.ts
+++ b/src.ts/tests/ffi.spec.ts
@@ -1,4 +1,4 @@
-import { bytesToHex } from '@ethereumjs/util'
+import { bytesToHex, randomBytes } from '@ethereumjs/util'
 import { beforeAll, describe, expect, test } from 'vitest'
 
 import { VerkleCrypto, loadVerkleCrypto } from '../index.js'
@@ -202,8 +202,7 @@ describe('bindings', () => {
   })
 
   test('verifyExecutionProof: invalid state root', () => {
-    // Src: Kaustinen6 testnet, block 72 state root (parent of block 73)
-    const prestateRoot = '0x000000006ccc6f34d14af48a865895bf34bde7f3571d9ba24a4b98122841048c'
+    const prestateRoot = bytesToHex(randomBytes(32))
     const executionWitness = JSON.stringify(kaustinenBlock73.executionWitness)
 
     const verified = verifyExecutionWitnessPreState(prestateRoot, executionWitness)

--- a/src.ts/tests/ffi.spec.ts
+++ b/src.ts/tests/ffi.spec.ts
@@ -192,7 +192,6 @@ describe('bindings', () => {
     expect(verified).toBe(true)
   })
 
-  // This one is for a much larger block (~100 txs) and currently fails
   test('verifyExecutionProof: block with many txs', () => {
     // Src: Kaustinen6 testnet, block 72 state root (parent of block 73)
     const prestateRoot = '0x18d1dfcc6ccc6f34d14af48a865895bf34bde7f3571d9ba24a4b98122841048c'
@@ -200,6 +199,15 @@ describe('bindings', () => {
 
     const verified = verifyExecutionWitnessPreState(prestateRoot, executionWitness)
     expect(verified).toBe(true)
+  })
+
+  test('verifyExecutionProof: invalid state root', () => {
+    // Src: Kaustinen6 testnet, block 72 state root (parent of block 73)
+    const prestateRoot = '0x000000006ccc6f34d14af48a865895bf34bde7f3571d9ba24a4b98122841048c'
+    const executionWitness = JSON.stringify(kaustinenBlock73.executionWitness)
+
+    const verified = verifyExecutionWitnessPreState(prestateRoot, executionWitness)
+    expect(verified).toBe(false)
   })
 
   test('smoke test errors are thrown', () => {


### PR DESCRIPTION
This updates to a version of rust-verkle that returns false on a malformed pre state root.

Malformed here means that deserialization of the hex string to a point fails. It was already returning false on well-formed, but incorrect state roots.