### PR TITLE
Add `serializeCommitment` to public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to 
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.4.4 - 2024-06-11
+
+- Add `serializeCommitment` to to the public API, PR [#52](https://github.com/ethereumjs/verkle-cryptography-wasm/pull/52)
+
 ## 0.4.3 - 2024-06-03
 
 - Add `hashCommitment` to the public API and add new test to demonstrate how to derive a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 0.4.4 - 2024-06-11
 
-- Add `serializeCommitment` to to the public API, PR [#52](https://github.com/ethereumjs/verkle-cryptography-wasm/pull/52)
+- Add `serializeCommitment` to to the public API, PR [#53](https://github.com/ethereumjs/verkle-cryptography-wasm/pull/53)
 
 ## 0.4.3 - 2024-06-03
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "verkle-cryptography-wasm",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "verkle-cryptography-wasm",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT/Apache",
       "dependencies": {
         "@scure/base": "^1.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verkle-cryptography-wasm",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Verkle Trie Crytography WASM/TypeScript Bindings",
   "keywords": [
     "ethereum",

--- a/src.ts/index.ts
+++ b/src.ts/index.ts
@@ -33,13 +33,15 @@ export const loadVerkleCrypto = async (): Promise<VerkleCrypto> => {
   const zeroCommitment = zeroCommitmentBase()
 
   const hashCommitment = (commitment: Uint8Array) => verkleFFI.hashCommitment(commitment)
+  const serializeCommitment = (commitment: Uint8Array) => verkleFFI.serializeCommitment(commitment)
   return {
     getTreeKey,
     getTreeKeyHash,
     updateCommitment,
     zeroCommitment,
     verifyExecutionWitnessPreState,
-    hashCommitment
+    hashCommitment,
+    serializeCommitment
   }
 }
 
@@ -55,6 +57,7 @@ export interface VerkleCrypto {
   zeroCommitment: Uint8Array
   verifyExecutionWitnessPreState: (prestateRoot: string, execution_witness_json: string) => boolean
   hashCommitment: (commitment: Uint8Array) => Uint8Array
+  serializeCommitment: (commitment: Uint8Array) => Uint8Array
 }
 
 // This is a 32 byte serialized field element


### PR DESCRIPTION
Adds `serializeCommitment` which produces a compresses 32byte commitment from an uncompressed 64 byte equivalent that is used when updating the root of a verkle trie

Also, bump version to 0.4.4