### PR TITLE
Remove verkleCrypto interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to 
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.4.4 - 2024-06-21
+
+- Remove duplicative `VerkleCrypto` typescript interface as unnecessary. [#55](https://github.com/ethereumjs/verkle-cryptography-wasm/pull/55)
+
 ## 0.4.3 - 2024-06-03
 
 - Add `hashCommitment` to the public API and add new test to demonstrate how to derive a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "verkle-cryptography-wasm",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "verkle-cryptography-wasm",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT/Apache",
       "dependencies": {
         "@scure/base": "^1.1.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "verkle-cryptography-wasm",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "verkle-cryptography-wasm",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT/Apache",
       "dependencies": {
         "@scure/base": "^1.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verkle-cryptography-wasm",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Verkle Trie Crytography WASM/TypeScript Bindings",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verkle-cryptography-wasm",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Verkle Trie Crytography WASM/TypeScript Bindings",
   "keywords": [
     "ethereum",

--- a/src.ts/index.ts
+++ b/src.ts/index.ts
@@ -8,7 +8,7 @@ import {
 } from './verkleFFIBindings/index.js'
 import { Context as VerkleFFI } from './wasm/rust_verkle_wasm.js'
 
-export const loadVerkleCrypto = async (): Promise<VerkleCrypto> => {
+export const loadVerkleCrypto = async () => {
   await initVerkleWasm()
 
   const verkleFFI = new VerkleFFI()
@@ -41,20 +41,6 @@ export const loadVerkleCrypto = async (): Promise<VerkleCrypto> => {
     verifyExecutionWitnessPreState,
     hashCommitment
   }
-}
-
-export interface VerkleCrypto {
-  getTreeKey: (address: Uint8Array, treeIndex: Uint8Array, subIndex: number) => Uint8Array
-  getTreeKeyHash: (address: Uint8Array, treeIndexLE: Uint8Array) => Uint8Array
-  updateCommitment: (
-    commitment: Uint8Array,
-    commitmentIndex: number,
-    oldScalarValue: Uint8Array,
-    newScalarValue: Uint8Array
-  ) => Commitment
-  zeroCommitment: Uint8Array
-  verifyExecutionWitnessPreState: (prestateRoot: string, execution_witness_json: string) => boolean
-  hashCommitment: (commitment: Uint8Array) => Uint8Array
 }
 
 // This is a 32 byte serialized field element


### PR DESCRIPTION
As noted in #54, the `VerkleCrypto` interface is duplicative here and unnecessary.  Typescript can already infer the type of `loadVerkleCrypto` and this VerkleCrypto interface is already found in the `@ethereumjs/util` package.