### PR TITLE
chore!: Add tests for createProof and verifyProof alongside an easier to use abstraction

### DIFF
--- a/src.rs/src/verkle_ffi_api.rs
+++ b/src.rs/src/verkle_ffi_api.rs
@@ -219,7 +219,7 @@ impl Context {
     {
         let input_bytes = serde_wasm_bindgen::from_value(input.into()).unwrap();
         let result = ffi_interface::verify_proof(&self.inner, input_bytes).map(|_op |Boolean::from(true))
-        .map_err(|err| JsError::new(&format!("proof verification failed]: {:?}", err)));
+        .map_err(|err| JsError::new(&format!("proof verification failed: {:?}", err)));
         return result
     }
 }

--- a/src.ts/index.ts
+++ b/src.ts/index.ts
@@ -7,6 +7,8 @@ import {
   verifyExecutionWitnessPreState as verifyExecutionWitnessPreStateBase,
   createProof as createProofBase,
   verifyProof as verifyProofBase,
+  ProverInput as ProverInputBase,
+  VerifierInput as VerifierInputBase,
 } from './verkleFFIBindings/index.js'
 import { Context as VerkleFFI } from './wasm/rust_verkle_wasm.js'
 
@@ -29,15 +31,18 @@ export const loadVerkleCrypto = async () => {
   ): Commitment =>
     updateCommitmentBase(verkleFFI, commitment, commitmentIndex, oldScalarValue, newScalarValue)
 
-  const verifyExecutionWitnessPreState = (prestateRoot: string, execution_witness_json: string): boolean =>
-    verifyExecutionWitnessPreStateBase(prestateRoot, execution_witness_json)
+  const verifyExecutionWitnessPreState = (
+    prestateRoot: string,
+    execution_witness_json: string,
+  ): boolean => verifyExecutionWitnessPreStateBase(prestateRoot, execution_witness_json)
 
   const zeroCommitment = zeroCommitmentBase()
 
   const hashCommitment = (commitment: Uint8Array) => verkleFFI.hashCommitment(commitment)
   const serializeCommitment = (commitment: Uint8Array) => verkleFFI.serializeCommitment(commitment)
-  const createProof = (input: Uint8Array) => verkleFFI.createProof(input)
-  const verifyProof = (proofInput: Uint8Array) => verkleFFI.verifyProof(proofInput)
+  const createProof = (proverInputs: ProverInput[]) => createProofBase(verkleFFI, proverInputs)
+  const verifyProof = (proof: Uint8Array, verifierInputs: VerifierInput[]) =>
+    verifyProofBase(verkleFFI, proof, verifierInputs)
   return {
     getTreeKey,
     getTreeKeyHash,
@@ -47,9 +52,15 @@ export const loadVerkleCrypto = async () => {
     hashCommitment,
     serializeCommitment,
     createProof,
-    verifyProof
+    verifyProof,
   }
 }
+
+// Input used to create proofs over vectors
+export type ProverInput = ProverInputBase
+// Input needed to verify proofs over vectors
+// alongside the proof.
+export type VerifierInput = VerifierInputBase
 
 // This is a 32 byte serialized field element
 export type Scalar = Uint8Array

--- a/src.ts/index.ts
+++ b/src.ts/index.ts
@@ -7,8 +7,8 @@ import {
   verifyExecutionWitnessPreState as verifyExecutionWitnessPreStateBase,
   createProof as createProofBase,
   verifyProof as verifyProofBase,
-  ProverInput as ProverInputBase,
-  VerifierInput as VerifierInputBase,
+  type ProverInput as ProverInputBase,
+  type VerifierInput as VerifierInputBase,
 } from './verkleFFIBindings/index.js'
 import { Context as VerkleFFI } from './wasm/rust_verkle_wasm.js'
 

--- a/src.ts/tests/ffi.spec.ts
+++ b/src.ts/tests/ffi.spec.ts
@@ -1,7 +1,7 @@
 import { bytesToHex, randomBytes } from '@ethereumjs/util'
 import { beforeAll, describe, expect, test, assert } from 'vitest'
 
-import { ProverInput, VerifierInput, VerkleCrypto, loadVerkleCrypto } from '../index.js'
+import { ProverInput, VerifierInput, loadVerkleCrypto } from '../index.js'
 import { verifyExecutionWitnessPreState, Context as VerkleFFI } from '../wasm/rust_verkle_wasm.js'
 
 import kaustinenBlock72 from './data/kaustinen6Block72.json'
@@ -9,7 +9,7 @@ import kaustinenBlock73 from './data/kaustinen6Block73.json'
 
 describe('bindings', () => {
   let ffi: VerkleFFI
-  let verkleCrypto: VerkleCrypto
+  let verkleCrypto: Awaited<ReturnType<typeof loadVerkleCrypto>>
   beforeAll(async () => {
     verkleCrypto = await loadVerkleCrypto()
     ffi = new VerkleFFI()

--- a/src.ts/verkleFFIBindings/index.ts
+++ b/src.ts/verkleFFIBindings/index.ts
@@ -1,6 +1,18 @@
-import { initVerkleWasm, zeroCommitment, verifyExecutionWitnessPreState } from '../wasm/rust_verkle_wasm.js'
+import {
+  initVerkleWasm,
+  zeroCommitment,
+  verifyExecutionWitnessPreState,
+} from '../wasm/rust_verkle_wasm.js'
 
-import { getTreeKey, getTreeKeyHash, updateCommitment, createProof, verifyProof } from './verkleFFI.js'
+import {
+  getTreeKey,
+  getTreeKeyHash,
+  updateCommitment,
+  createProof,
+  verifyProof,
+  ProverInput,
+  VerifierInput,
+} from './verkleFFI.js'
 
 export {
   initVerkleWasm,
@@ -10,5 +22,7 @@ export {
   zeroCommitment,
   verifyExecutionWitnessPreState,
   createProof,
-  verifyProof
+  verifyProof,
+  ProverInput,
+  VerifierInput,
 }

--- a/src.ts/verkleFFIBindings/index.ts
+++ b/src.ts/verkleFFIBindings/index.ts
@@ -10,8 +10,8 @@ import {
   updateCommitment,
   createProof,
   verifyProof,
-  ProverInput,
-  VerifierInput,
+  type ProverInput,
+  type VerifierInput,
 } from './verkleFFI.js'
 
 export {
@@ -23,6 +23,6 @@ export {
   verifyExecutionWitnessPreState,
   createProof,
   verifyProof,
-  ProverInput,
-  VerifierInput,
+  type ProverInput,
+  type VerifierInput,
 }


### PR DESCRIPTION
Breaking change as the input for createProof and verifyProof have been changed to ProverInput and VerifierInput.

This PR was initially meant to add tests for the existing interface, however it got a bit unwieldly so I made a quick interface to abstract away the boiletplate code for serializing and duplicating vectors.

pinging @acolytec3 since we just discussed him doing something similar. Feel free to merge your interface change in and I'll modify the tests, goal is just to have readable testing code so whichever interface works for me