### PR TITLE
Add `commitToScalars` and version bump

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
       "source.fixAll.eslint": "explicit"
     },
     "eslint.format.enable": true,
-    "eslint.workingDirectories": [{ "pattern": "./*" }]
+    "eslint.workingDirectories": [{ "pattern": "./*" }],
+    "rust-analyzer.procMacro.enable": true
   }
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to 
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.4.7 - 2024-09-12
+
+- Expose `commitToScalars` in public API. #[57](https://github.com/ethereumjs/verkle-cryptography-wasm/pull/57)
+
 ## 0.4.6 - 2024-09-08
 
 - Expose `createProof` and `verifyProof` from verkle_ffi. #[56](https://github.com/ethereumjs/verkle-cryptography-wasm/pull/56)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "verkle-cryptography-wasm",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "verkle-cryptography-wasm",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "MIT/Apache",
       "dependencies": {
         "@scure/base": "^1.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verkle-cryptography-wasm",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Verkle Trie Crytography WASM/TypeScript Bindings",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verkle-cryptography-wasm",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Verkle Trie Crytography WASM/TypeScript Bindings",
   "keywords": [
     "ethereum",

--- a/src.ts/index.ts
+++ b/src.ts/index.ts
@@ -7,6 +7,7 @@ import {
   verifyExecutionWitnessPreState as verifyExecutionWitnessPreStateBase,
   createProof as createProofBase,
   verifyProof as verifyProofBase,
+  commitToScalars as commitToScalarsBase,
   type ProverInput as ProverInputBase,
   type VerifierInput as VerifierInputBase,
 } from './verkleFFIBindings/index.js'
@@ -43,7 +44,9 @@ export const loadVerkleCrypto = async () => {
   const createProof = (proverInputs: ProverInput[]) => createProofBase(verkleFFI, proverInputs)
   const verifyProof = (proof: Uint8Array, verifierInputs: VerifierInput[]) =>
     verifyProofBase(verkleFFI, proof, verifierInputs)
+  const commitToScalars = (vector: Uint8Array[]) => commitToScalarsBase(verkleFFI, vector)
   return {
+    commitToScalars, 
     getTreeKey,
     getTreeKeyHash,
     updateCommitment,

--- a/src.ts/verkleFFIBindings/index.ts
+++ b/src.ts/verkleFFIBindings/index.ts
@@ -5,6 +5,7 @@ import {
 } from '../wasm/rust_verkle_wasm.js'
 
 import {
+  commitToScalars,
   getTreeKey,
   getTreeKeyHash,
   updateCommitment,
@@ -15,6 +16,7 @@ import {
 } from './verkleFFI.js'
 
 export {
+  commitToScalars, 
   initVerkleWasm,
   getTreeKey,
   getTreeKeyHash,

--- a/src.ts/verkleFFIBindings/verkleFFI.ts
+++ b/src.ts/verkleFFIBindings/verkleFFI.ts
@@ -136,15 +136,7 @@ export interface ProverInput {
   // The vector that we want to make proofs over
   vector: Uint8Array[]
   // The indices that we want to prove exist in the vector
-  inindices.flatMap((index) => [
-      serializedCommitment,
-      ...vector,
-      new Uint8Array([index]),
-      vector[index],
-    ]),
-  )
-
-  return concatBytes(...serializedProverInputs)
+  indices: number[]
 }
 
 export interface VerifierInput {

--- a/src.ts/verkleFFIBindings/verkleFFI.ts
+++ b/src.ts/verkleFFIBindings/verkleFFI.ts
@@ -139,6 +139,19 @@ export interface ProverInput {
   indices: number[]
 }
 
+function serializedProverInputs(proofInputs: ProverInput[]): Uint8Array {
+  const serializedProverInputs = proofInputs.flatMap(({ serializedCommitment, vector, indices }) =>
+    indices.flatMap((index) => [
+      serializedCommitment,
+      ...vector,
+      new Uint8Array([index]),
+      vector[index],
+    ]),
+  )
+
+  return concatBytes(...serializedProverInputs)
+}
+
 export interface VerifierInput {
   // A commitment to the vector that we want to verify
   // proofs over.

--- a/src.ts/verkleFFIBindings/verkleFFI.ts
+++ b/src.ts/verkleFFIBindings/verkleFFI.ts
@@ -136,12 +136,7 @@ export interface ProverInput {
   // The vector that we want to make proofs over
   vector: Uint8Array[]
   // The indices that we want to prove exist in the vector
-  indices: number[]
-}
-
-function serializedProverInputs(proofInputs: ProverInput[]): Uint8Array {
-  const serializedProverInputs = proofInputs.flatMap(({ serializedCommitment, vector, indices }) =>
-    indices.flatMap((index) => [
+  inindices.flatMap((index) => [
       serializedCommitment,
       ...vector,
       new Uint8Array([index]),
@@ -177,4 +172,14 @@ function serializeVerifierInputs(proof: Uint8Array, verifierInputs: VerifierInpu
   ]
 
   return concatBytes(...serializedVerifierInputs)
+}
+
+/**
+ * 
+ * @param verkleFFI The interface to the WASM verkle crypto object
+ * @param vector an array of Uint8Arrays to be committed to (must be 32 bytes each)
+ * @returns a 64 byte {@link Uint8Array}  uncompressed commitment to the {@link vector} of values
+ */
+export const commitToScalars = (verkleFFI: VerkleFFI, vector: Uint8Array[]) => {
+  return verkleFFI.commitToScalars(vector)
 }


### PR DESCRIPTION
Exposes the `commitToScalars` method in the public API to allow for more efficient commitment generation when we're updating a whole set of values at once.

Also does a simultaneous version bump.